### PR TITLE
Fix pom.xml to remove unavailable repository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,23 +89,6 @@
 
   </distributionManagement>
 
-  <repositories>
-
-    <repository>
-      <id>repo.oqube.com</id>
-      <name>OQube</name>
-      <url>http://www.oqube.com/maven2</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
-      </snapshots>
-    </repository>
-
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
This caused the build to fail on JUnit and one other jar. The build
seems to work anyway without this repository, so I don't think it is
needed.