### PR TITLE
Fix most build deprecation warnings and provide generics for Transitions.

### DIFF
--- a/jautomata-core/pom.xml
+++ b/jautomata-core/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>oqube</groupId>
   <artifactId>jautomata-core</artifactId>
-  <version>${parent.version}</version>
+
   <packaging>jar</packaging>
   <name>JAutomata Core</name>
   <description>

--- a/jautomata-core/src/main/java/rationals/Transition.java
+++ b/jautomata-core/src/main/java/rationals/Transition.java
@@ -29,13 +29,13 @@ package rationals;
  * @version 1.0
  * @see Automaton
  */
-public class Transition {
+public class Transition<E> {
 
   private int hash = Integer.MIN_VALUE;
 
   private State start;
 
-  private Object label;
+  private E label;
 
   private State end;
 
@@ -49,7 +49,7 @@ public class Transition {
    * @param end
    *          the state <em>q'</em> for this transition <em>(q , l , q')</em>.
    */
-  public Transition(State start, Object label, State end) {
+  public Transition(State start, E label, State end) {
     this.start = start;
     this.label = label;
     this.end = end;
@@ -82,7 +82,7 @@ public class Transition {
    * @return the label state of this transition, that is the object <em>l</em>
    *         for this transition <em>(q , l , q')</em>.
    */
-  public Object label() {
+  public E label() {
     return label;
   }
 
@@ -170,7 +170,7 @@ public class Transition {
    * 
    * @param msg
    */
-  void setLabel(Object obj) {
+  void setLabel(E obj) {
     this.label = obj;
   }
 

--- a/jautomata-ext/pom.xml
+++ b/jautomata-ext/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>oqube</groupId>
   <artifactId>jautomata-ext</artifactId>
-  <version>${parent.version}</version>
+
   <packaging>jar</packaging>
   <name>JAutomata extensions</name>
   <description>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>oqube</groupId>
       <artifactId>jautomata-core</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
 
 

--- a/jautomata-graph/pom.xml
+++ b/jautomata-graph/pom.xml
@@ -10,7 +10,7 @@
 
  <groupId>oqube</groupId>
  <artifactId>jautomata-graph</artifactId>
- <version>${parent.version}</version>
+
  <packaging>jar</packaging>
  <name>JAutomata Graph interface</name>
  <description>

--- a/jautomata-io/pom.xml
+++ b/jautomata-io/pom.xml
@@ -10,7 +10,7 @@
 
  <groupId>oqube</groupId>
  <artifactId>jautomata-io</artifactId>
- <version>${parent.version}</version>
+
  <packaging>jar</packaging>
  <name>JAutomata I/O</name>
  <description>
@@ -22,7 +22,7 @@
   <dependency>
    <groupId>oqube</groupId>
    <artifactId>jautomata-graph</artifactId>
-   <version>${parent.version}</version>
+   <version>${project.parent.version}</version>
   </dependency>
 
  </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,10 @@
     </dependencies>
   </dependencyManagement>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <build>
 
     <extensions>
@@ -120,16 +124,21 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-          <fork>true</fork>
+          <source>1.7</source>
+          <target>1.7</target>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
+          <compilerArgument>-Xlint:all</compilerArgument>
         </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
+        <version>1.7.2</version>
         <configuration>
           <locales>en</locales>
         </configuration>
@@ -153,6 +162,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>surefire-report-maven-plugin</artifactId>
+        <version>2.18.1</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
This commit leaves many warnings about generics unfixed for now, but does turn the reporting of warnings on.